### PR TITLE
Show busy spinner on channel button during upload (#11)

### DIFF
--- a/ui/src/components/main/Entry.jsx
+++ b/ui/src/components/main/Entry.jsx
@@ -148,7 +148,7 @@ const Uploader = ({
     );
 };
 
-const Entry = ({selectedDevice, selectedEntry, useWide, setDevice, selectedSlotId, setError}) => {
+const Entry = ({selectedDevice, selectedEntry, useWide, setDevice, selectedSlotId, setError, setUploadPendingSlotId}) => {
     const [uploadSlotId, setUploadSlotId] = useState(null);
     const [sendGain, setSendGain] = useState(false);
     const [pending, setPending] = useState(false);
@@ -183,16 +183,19 @@ const Entry = ({selectedDevice, selectedEntry, useWide, setDevice, selectedSlotI
                     }) : []
                 } : null;
                 setPending(true);
+                if (setUploadPendingSlotId) setUploadPendingSlotId(uploadSlotId);
                 try {
                     const call = gains
                         ? () => ezbeq.loadWithMV(selectedDevice.name, selectedEntry.id, uploadSlotId, gains)
                         : () => ezbeq.sendFilter(selectedDevice.name, selectedEntry.id, uploadSlotId);
                     const device = await call();
                     setPending(false);
+                    if (setUploadPendingSlotId) setUploadPendingSlotId(null);
                     setDevice(device);
                 } catch (e) {
                     setError(e);
                     setPending(false);
+                    if (setUploadPendingSlotId) setUploadPendingSlotId(null);
                 }
             }
         }

--- a/ui/src/components/main/Slots.jsx
+++ b/ui/src/components/main/Slots.jsx
@@ -94,7 +94,7 @@ const Slot = ({selected, slot, onSelect, isPending, onClear}) => {
     );
 };
 
-const Slots = ({selectedDevice, selectedSlotId, useWide, setDevice, setUserDriven, setError}) => {
+const Slots = ({selectedDevice, selectedSlotId, useWide, setDevice, setUserDriven, setError, uploadPendingSlotId}) => {
 
     const [pending, setPending] = useState([]);
     const [currentGains, setCurrentGains] = useState(defaultGain);
@@ -185,7 +185,7 @@ const Slots = ({selectedDevice, selectedSlotId, useWide, setDevice, setUserDrive
     };
 
     const isPending = (slotId) => {
-        return getCurrentState(pending, 'clear', slotId) === 1 || getCurrentState(pending, 'activate', slotId) === 1;
+        return getCurrentState(pending, 'clear', slotId) === 1 || getCurrentState(pending, 'activate', slotId) === 1 || uploadPendingSlotId === slotId;
     };
 
     const rows = chunk(selectedDevice && selectedDevice.hasOwnProperty('slots') ? selectedDevice.slots : [], 2);

--- a/ui/src/components/main/index.jsx
+++ b/ui/src/components/main/index.jsx
@@ -34,6 +34,7 @@ const MainView = ({
     const [selectedEntryId, setSelectedEntryId] = useState(-1);
     const [userDriven, setUserDriven] = useState(false);
     const [filteredEntries, setFilteredEntries] = useState([]);
+    const [uploadPendingSlotId, setUploadPendingSlotId] = useState(null);
 
     const toggleShowFilters = () => {
         setShowFilters((prev) => !prev);
@@ -102,7 +103,8 @@ const MainView = ({
                            setSelectedSlotId={setSelectedSlotId}
                            setUserDriven={setUserDriven}
                            setDevice={d => replaceDevice(d)}
-                           setError={setErr}/>;
+                           setError={setErr}
+                           uploadPendingSlotId={uploadPendingSlotId}/>;
     const catalogue = <Catalogue entries={filteredEntries}
                                  setSelectedEntryId={setSelectedEntryId}
                                  selectedEntryId={selectedEntryId}
@@ -113,7 +115,8 @@ const MainView = ({
                          useWide={useWide}
                          setDevice={d => replaceDevice(d)}
                          selectedSlotId={selectedSlotId}
-                         setError={setErr}/>;
+                         setError={setErr}
+                         setUploadPendingSlotId={setUploadPendingSlotId}/>;
     const footer = <Footer meta={meta}/>;
     return (
         <>


### PR DESCRIPTION
## Summary

- When uploading a profile to a slot, the spinner now appears on both the Upload button and the target channel/slot button
- Tracks upload pending state in `MainView` and propagates it down to `Slots` so the correct channel button shows a spinner during upload
- Closes #11

## Test plan

- [ ] Select a device and choose a profile from the catalogue
- [ ] Click Upload — verify spinner appears on both the Upload button and the target channel button simultaneously
- [ ] Verify spinner clears from both locations when upload completes
- [ ] Verify spinner clears on error as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)