### PR TITLE
ux: surface backend errors and show device disconnected banner (#12)

### DIFF
--- a/ezbeq/apis/ws.py
+++ b/ezbeq/apis/ws.py
@@ -210,6 +210,9 @@ class WsServer(abc.ABC, Generic[T]):
     def broadcast(self, msg: str):
         self.factory.broadcast(msg)
 
+    def broadcast_error(self, msg: str, persistent: bool = False):
+        self.broadcast(json.dumps({'message': 'Error', 'data': msg, 'persistent': persistent}))
+
     def levels(self, device: str, levels: dict) -> bool:
         return self.factory.send_levels(device, json.dumps({'message': 'Levels', 'data': levels}))
 

--- a/ezbeq/minidsp.py
+++ b/ezbeq/minidsp.py
@@ -32,6 +32,7 @@ class MinidspState(DeviceState):
         self.__mute: bool = kwargs['mute'] if 'mute' in kwargs else False
         self.__active_slot: str = kwargs['active_slot'] if 'active_slot' in kwargs else ''
         self.__serials: list = kwargs['serials'] if 'serials' in kwargs else []
+        self.connected: bool = kwargs.get('connected', True)
         self.__descriptor = descriptor
         slot_ids = [str(i + 1) for i in range(4)]
         self.__slots: list[MinidspSlotState] = [
@@ -108,6 +109,7 @@ class MinidspState(DeviceState):
             'name': self.__name,
             'masterVolume': self.master_volume,
             'mute': self.__mute,
+            'connected': self.connected,
             'slots': [s.as_dict() for s in self.__slots],
         } | serials
 
@@ -486,7 +488,7 @@ class Minidsp(PersistentDevice[MinidspState]):
 
     def __load_state(self) -> MinidspState:
         result = self.__executor.submit(self.__read_state_from_device).result(timeout=self.__cmd_timeout)
-        return result if result else MinidspState(self.name, self.__descriptor)
+        return result if result else MinidspState(self.name, self.__descriptor, connected=False)
 
     def __read_state_from_device(self) -> MinidspState | None:
         output = None
@@ -698,7 +700,11 @@ class Minidsp(PersistentDevice[MinidspState]):
     def state(self, refresh: bool = False) -> MinidspState:
         if not self._hydrate() or refresh is True:
             new_state = self.__load_state()
+            old_connected = self._current_state.connected
             self._current_state.update_master_state(new_state.mute, new_state.master_volume)
+            self._current_state.connected = new_state.connected
+            if old_connected != self._current_state.connected:
+                self._broadcast()
         return self._current_state
 
     def _merge_state(self, loaded: MinidspState, cached: dict) -> MinidspState:

--- a/ezbeq/minidsp.py
+++ b/ezbeq/minidsp.py
@@ -521,9 +521,13 @@ class Minidsp(PersistentDevice[MinidspState]):
                     logger.warning(f'[{self.name}] Unable to probe')
                 return MinidspState(self.name, self.__descriptor, **values)
             else:
-                logger.error(f"[{self.name}] No output returned from device")
+                msg = f"[{self.name}] No output returned from device"
+                logger.error(msg)
+                self.ws_server.broadcast_error(msg, persistent=True)
         except:
-            logger.exception(f"[{self.name}] Unable to parse device state {output}")
+            msg = f"[{self.name}] Unable to parse device state {output}"
+            logger.exception(msg)
+            self.ws_server.broadcast_error(msg, persistent=True)
         return None
 
     @staticmethod

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -6,6 +6,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import CssBaseline from '@mui/material/CssBaseline';
 import {pushData} from "./services/util";
 import ErrorSnack from "./components/ErrorSnack";
+import DeviceDisconnectedBanner from "./components/DeviceDisconnectedBanner";
 import MainView from "./components/main";
 import Levels from "./components/levels";
 import Minidsp from "./components/minidsp";
@@ -128,6 +129,11 @@ const App = () => {
                 <CssBaseline/>
                 <Root>
                     <ErrorSnack err={err} setErr={setErr}/>
+                    {
+                        selectedDeviceName && availableDevices[selectedDeviceName]?.connected === false
+                            ? <DeviceDisconnectedBanner deviceName={selectedDeviceName}/>
+                            : null
+                    }
                     {
                         selectedNav === 'catalogue'
                             ?

--- a/ui/src/components/DeviceDisconnectedBanner.jsx
+++ b/ui/src/components/DeviceDisconnectedBanner.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
+
+const DeviceDisconnectedBanner = ({deviceName}) => {
+    return (
+        <Alert
+            severity="error"
+            variant="filled"
+            sx={{borderRadius: 0, width: '100%'}}
+        >
+            <AlertTitle>Device Unreachable</AlertTitle>
+            {deviceName} is not responding — check connection and review ezbeq.log
+        </Alert>
+    );
+};
+
+export default DeviceDisconnectedBanner;

--- a/ui/src/components/ErrorSnack.jsx
+++ b/ui/src/components/ErrorSnack.jsx
@@ -1,38 +1,50 @@
 import React, {useEffect, useState} from 'react';
 import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
 import IconButton from '@mui/material/IconButton';
 import CloseIcon from '@mui/icons-material/Close';
 
 const ErrorSnack = ({err, setErr}) => {
     const [errTxt, setErrTxt] = useState(null);
+    const [persistent, setPersistent] = useState(false);
 
     useEffect(() => {
         if (err) {
             console.error(err);
             setErrTxt(err.message);
+            setPersistent(!!err.persistent);
         } else {
             setErrTxt(null);
+            setPersistent(false);
         }
     }, [err, setErrTxt]);
 
     const handleClose = (event, reason) => {
+        if (persistent && reason === 'clickaway') {
+            return;
+        }
         setErr(null);
     };
 
     return (
         <Snackbar
             open={errTxt !== null}
-            autoHideDuration={10000}
+            autoHideDuration={persistent ? null : 10000}
             onClose={handleClose}
-            message={err ? err.message : null}
-            action={
-                <>
+            anchorOrigin={persistent ? {vertical: 'top', horizontal: 'center'} : {vertical: 'bottom', horizontal: 'left'}}
+        >
+            <Alert
+                severity="error"
+                variant={persistent ? 'filled' : 'standard'}
+                action={
                     <IconButton size="small" aria-label="close" color="inherit" onClick={handleClose}>
                         <CloseIcon fontSize="small"/>
                     </IconButton>
-                </>
-            }
-        />
+                }
+            >
+                {errTxt}
+            </Alert>
+        </Snackbar>
     );
 }
 

--- a/ui/src/services/state.js
+++ b/ui/src/services/state.js
@@ -29,7 +29,11 @@ class StateService {
                     this.replaceDevice(payload.data);
                     break;
                 case 'Error':
-                    this.setErr(new Error(payload.data));
+                    const err = new Error(payload.data);
+                    if (payload.persistent) {
+                        err.persistent = true;
+                    }
+                    this.setErr(err);
                     break;
                 case 'Catalogue':
                     if (payload.data) {


### PR DESCRIPTION
## Summary

Closes #12

- **Backend errors now reach the UI**: When the minidsp device is unreachable (`Unable to parse device state None` and similar), the error is broadcast over WebSocket in addition to being logged. No more silent failures.
- **Persistent error display**: WebSocket-originated errors are shown as a filled red Alert anchored top-center with no auto-dismiss — requires explicit close. Regular (transient) errors keep the existing 10s auto-hide behaviour.
- **Device disconnected banner**: A full-width red banner is rendered at the top of the page whenever the selected device reports `connected=false`. It appears automatically on connection failure and clears itself when the device recovers — no user interaction needed.

## How it works

- `MinidspState` now carries a `connected: bool` field (serialised to the frontend). `__load_state` sets it `False` when the device can't be read. If connectivity status changes during a state refresh, the updated state is broadcast over WebSocket so all clients update immediately.
- `WsServer.broadcast_error(msg, persistent)` is a new convenience method for sending structured error messages with an optional persistence flag.
- `DeviceDisconnectedBanner` is a new React component; `App.jsx` renders it above all views when the selected device is disconnected.

## Test plan

- [ ] Start ezbeq with a minidsp device that is powered off / unreachable
- [ ] Confirm the red "Device Unreachable" banner appears at the top of the page
- [ ] Power the device on; confirm the banner disappears without a page refresh
- [ ] Confirm the persistent error snackbar also appears (top-centre, filled red, no auto-dismiss) and requires manual close
- [ ] Confirm normal (non-device) errors still auto-dismiss after 10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)